### PR TITLE
休憩画面の作成

### DIFF
--- a/VBTwatch Watch App/Model/TrainingData.swift
+++ b/VBTwatch Watch App/Model/TrainingData.swift
@@ -54,7 +54,7 @@ extension TrainingData {
 extension TrainingData {
     static let sampleData: [TrainingData] =
     [
-        TrainingData(objective: Objective(title: "筋肥大", velocity: 0.46, perRM: 80, image: "custom.figure.strengthtraining.traditional"), weight: 50, setCount: 2, sets: [TrainingSet(reps: [], averageVelocity: 0.41, maxVelocity: 0.55), TrainingSet(reps: [TrainingRep(velocity: 0.34, velocityLoss: 20, targetError: 1.12)], averageVelocity: 0.34, maxVelocity: 0.45)], maxVelocityLoss: 30, date: Date()),
-        TrainingData(objective: Objective(title: "スピード筋力", velocity: 0.94, perRM: 50, image: "custom.figure.core.training"), weight: 30, setCount: 3, sets: [], maxVelocityLoss: 25, date: Date())
+        TrainingData(objective: Objective(title: "筋肥大", velocity: 0.46, perRM: 80, image: "figure.strengthtraining.traditional"), weight: 50, setCount: 2, sets: [TrainingSet(reps: [], averageVelocity: 0.41, maxVelocity: 0.55), TrainingSet(reps: [TrainingRep(velocity: 0.34, velocityLoss: 20, targetError: 1.12)], averageVelocity: 0.34, maxVelocity: 0.45)], maxVelocityLoss: 30, date: Date()),
+        TrainingData(objective: Objective(title: "スピード筋力", velocity: 0.94, perRM: 50, image: "figure.core.training"), weight: 30, setCount: 3, sets: [], maxVelocityLoss: 25, date: Date())
     ]
 }

--- a/VBTwatch Watch App/Speech/Text.swift
+++ b/VBTwatch Watch App/Speech/Text.swift
@@ -10,8 +10,7 @@ import AVFoundation
 
 let synthesizer = AVSpeechSynthesizer()
 
-func speechVelocity(velocity: Double) {
-    let text = "\(velocity)"
+func speechText(text: String) {
     let utterance = AVSpeechUtterance(string: text)
     utterance.voice = AVSpeechSynthesisVoice(language: "ja-JP")
     utterance.rate = 0.55

--- a/VBTwatch Watch App/View/Prepare.swift
+++ b/VBTwatch Watch App/View/Prepare.swift
@@ -10,14 +10,13 @@ import SwiftUI
 struct Prepare: View {
     @Binding var trainingData: TrainingData
     @ObservedObject var countdown = Countdown(secondsRemaining: 5, canTransition: false)
-    @State var canTransition = false
     var body: some View {
         VStack {
             Image(trainingData.objective.image)
                 .font(.system(size: 70))
                 .foregroundColor(.pink)
             Text("準備").font(.system(size: 20))
-            Text("\(countdown.secondsRemaining)秒後に始まります").font(.system(size: 11))
+            Text("\(countdown.secondsRemaining)秒後に開始").font(.system(size: 15))
             if countdown.canTransition {
                 NavigationLink(destination: TrainingView(trainingData: $trainingData), isActive: $countdown.canTransition) {
                     EmptyView()

--- a/VBTwatch Watch App/View/RestView.swift
+++ b/VBTwatch Watch App/View/RestView.swift
@@ -1,0 +1,34 @@
+//
+//  RestView.swift
+//  VBTwatch Watch App
+//
+//  Created by Ryo Yoshitsugu on R 5/03/14.
+//
+
+import SwiftUI
+
+struct RestView: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var countdown = Countdown(secondsRemaining: 30, canTransition: false)
+    var body: some View {
+        VStack {
+            Image("figure.rower")
+                .font(.system(size: 70))
+                .foregroundColor(.pink)
+            Text("休憩").font(.system(size: 20))
+            Text("\(countdown.secondsRemaining)秒後に開始").font(.system(size: 15))
+            if countdown.canTransition {
+                let _ = dismiss()
+            }
+        }.onAppear {
+            countdown.startCountdown()
+        }
+        .navigationBarBackButtonHidden(true)
+    }
+}
+
+struct RestView_Previews: PreviewProvider {
+    static var previews: some View {
+        RestView()
+    }
+}

--- a/VBTwatch.xcodeproj/project.pbxproj
+++ b/VBTwatch.xcodeproj/project.pbxproj
@@ -33,9 +33,10 @@
 		63237AD629BC1F2A00BB0674 /* TrainingSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63237AD529BC1F2A00BB0674 /* TrainingSet.swift */; };
 		63237AD829BC1F7600BB0674 /* TrainingRep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63237AD729BC1F7600BB0674 /* TrainingRep.swift */; };
 		63237ADB29BC58E700BB0674 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63237ADA29BC58E700BB0674 /* Constant.swift */; };
+		636C325F29C03B4700044408 /* RestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636C325E29C03B4700044408 /* RestView.swift */; };
 		637AFA5F29B98A0C00FF7CDD /* TrainingData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637AFA5E29B98A0C00FF7CDD /* TrainingData.swift */; };
 		FE436A0129BB164E00EDB139 /* ButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE436A0029BB164E00EDB139 /* ButtonView.swift */; };
-		FE5D888229BEB98C008F94E9 /* Velocity.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5D888129BEB98C008F94E9 /* Velocity.swift */; };
+		FE5D888229BEB98C008F94E9 /* Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5D888129BEB98C008F94E9 /* Text.swift */; };
 		FEA9C97C29B9BBCF004D442D /* TrainingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA9C97B29B9BBCF004D442D /* TrainingView.swift */; };
 /* End PBXBuildFile section */
 
@@ -92,9 +93,10 @@
 		63237AD529BC1F2A00BB0674 /* TrainingSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainingSet.swift; sourceTree = "<group>"; };
 		63237AD729BC1F7600BB0674 /* TrainingRep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainingRep.swift; sourceTree = "<group>"; };
 		63237ADA29BC58E700BB0674 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
+		636C325E29C03B4700044408 /* RestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestView.swift; sourceTree = "<group>"; };
 		637AFA5E29B98A0C00FF7CDD /* TrainingData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrainingData.swift; sourceTree = "<group>"; };
 		FE436A0029BB164E00EDB139 /* ButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonView.swift; sourceTree = "<group>"; };
-		FE5D888129BEB98C008F94E9 /* Velocity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Velocity.swift; sourceTree = "<group>"; };
+		FE5D888129BEB98C008F94E9 /* Text.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Text.swift; sourceTree = "<group>"; };
 		FEA9C97B29B9BBCF004D442D /* TrainingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrainingView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -214,6 +216,7 @@
 				630110D229B9D5700063F7BB /* Prepare.swift */,
 				630110CD29B98DD00063F7BB /* EditView.swift */,
 				FEA9C97B29B9BBCF004D442D /* TrainingView.swift */,
+				636C325E29C03B4700044408 /* RestView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -229,7 +232,7 @@
 		FE5D888029BEB873008F94E9 /* Speech */ = {
 			isa = PBXGroup;
 			children = (
-				FE5D888129BEB98C008F94E9 /* Velocity.swift */,
+				FE5D888129BEB98C008F94E9 /* Text.swift */,
 			);
 			path = Speech;
 			sourceTree = "<group>";
@@ -351,10 +354,11 @@
 				63204D9D29B2CAA600D60018 /* ContentView.swift in Sources */,
 				630110CE29B98DD00063F7BB /* EditView.swift in Sources */,
 				630110D529BAB5F40063F7BB /* Countdown.swift in Sources */,
-				FE5D888229BEB98C008F94E9 /* Velocity.swift in Sources */,
+				FE5D888229BEB98C008F94E9 /* Text.swift in Sources */,
 				FE436A0129BB164E00EDB139 /* ButtonView.swift in Sources */,
 				63204DBB29B71DBC00D60018 /* HomeView.swift in Sources */,
 				630110D929BACE250063F7BB /* SummaryView.swift in Sources */,
+				636C325F29C03B4700044408 /* RestView.swift in Sources */,
 				630110DB29BAFBD80063F7BB /* SetDetailView.swift in Sources */,
 				63204DAF29B2DB4800D60018 /* ExtendedRunTime.swift in Sources */,
 				FEA9C97C29B9BBCF004D442D /* TrainingView.swift in Sources */,


### PR DESCRIPTION
# 概要
<!-- e.g. トレーニング時間、セット数、レストを入力し、データを編集する機能を作成-->
休憩中に表示する画面の作成
# 目的
<!-- e.g. ユーザーがトレーニングする際に、トレーニング時間、セット数、レストを自身が決めれる仕様にする -->
ユーザーが今どのようなステータス（トレーニング中or休憩中）かを確認できるようにする
# やったこと
<!-- e.g.
- [ ] 編集画面の作成
- [ ] 入力フォームの作成
- [ ] データの紐付け
-->
- [x] RestViewの作成
- [x] TrainingViewの修正(開始、終了を音声出力で知らせる)
# 変更内容
<!-- e.g. 変更した部分の画像、動画など -->
![スクリーンショット 0005-03-14 17 34 51](https://user-images.githubusercontent.com/52564598/224942629-8aaf4072-336d-4163-9b80-82e39cb200c0.png)

# 不安点、見てほしいところ
<!-- e.g. トレーニング時間の入力フォームについて。Sliderで作成したがPickerの方がいい？ -->
View/TrainingViewの138~142行目の部分
TrainingViewが表示されるとレップの開始を知らせる仕組みだが、重量変更のAlertから戻ると、onAppearが発火し、再度レップの知らせが来てしまう。
そこで解決策として、isBackFromAlert変数を用意し、アラートからTrainingViewnに遷移した場合のみ、レップの開始を知らせないという仕組みにした。
もっとスマートに解決できる方法があったら教えて〜
# その他
<!-- e.g. https://...を参考にしました。 -->
